### PR TITLE
Check motion position before passing into adapter

### DIFF
--- a/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
+++ b/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
@@ -945,7 +945,7 @@ public abstract class ExtendableListView extends AbsListView {
             mPerformClick = new PerformClick();
         }
         final int motionPosition = mMotionPosition;
-        if (!mDataChanged && mAdapter.isEnabled(motionPosition)) {
+        if (!mDataChanged && motionPosition > 0 && mAdapter.isEnabled(motionPosition)) {
             final PerformClick performClick = mPerformClick;
             performClick.mClickMotionPosition = motionPosition;
             performClick.rememberWindowAttachCount();


### PR DESCRIPTION
I saw it crashes the app if Staggered List has footer or header and the user hits the space between the list items.
This is because -1 is passed to `HeaderViewListAdapter.isEnabled(int position)`
Checking motion position before sending it to adapter fixes that.
