### PR TITLE
Bugfixes for notifyDatasetChanged and bad position checking

### DIFF
--- a/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
+++ b/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
@@ -631,7 +631,6 @@ public abstract class ExtendableListView extends AbsListView {
 
             mLayoutMode = LAYOUT_SYNC;
             mSyncPosition = Math.min(Math.max(0, mSyncPosition), count - 1);
-            if (mSyncPosition == 0) mLayoutMode = LAYOUT_FORCE_TOP;
             return;
         }
 


### PR DESCRIPTION
Possible bugfix for https://github.com/etsy/AndroidStaggeredGrid/issues/22 - why do we needed to LAYOUT_FORCE_TOP ?

My bad, in https://github.com/etsy/AndroidStaggeredGrid/pull/19 I should have checked if position is greater or equal to zero, instead of just is greater.
