### PR TITLE
Clean up duplicated build configuration

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,11 +1,3 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:0.7.3'
-    }
-}
 apply plugin: 'android-library'
 
 repositories {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,11 +1,3 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:0.7.3'
-    }
-}
 apply plugin: 'android'
 
 repositories {


### PR DESCRIPTION
Common configuration for multi-project can be placed in "root project"
