### PR TITLE
Fixed setAdapter bug

### DIFF
--- a/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
+++ b/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
@@ -265,7 +265,7 @@ public abstract class ExtendableListView extends AbsListView {
         }
 
         mDataChanged = true;
-        mItemCount = adapter != null ? adapter.getCount() : 0;
+        mItemCount = mAdapter != null ? mAdapter.getCount() : 0;
 
         if (adapter != null) {
             adapter.registerDataSetObserver(mObserver);


### PR DESCRIPTION
adapter should be mAdapter, otherwise when adding header view, mItemCount will get the original adapter's getCount(), which doesn't count the number of headers and/or footers. Later on in layoutChildren() method it'll throw IllegalStateException, because the number of mItemCount and mAdapter.getCount() will never be equal.
