### PR TITLE
Fix the adapter index to getItemId() to include the mFirstPosition offse...

### DIFF
--- a/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
+++ b/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
@@ -2741,7 +2741,7 @@ public abstract class ExtendableListView extends AbsListView {
                 final View view = getChildAt(motionPosition); // a fix by @pboos
 
                 if (view != null) {
-                    performItemClick(view, motionPosition + mFirstPosition, adapter.getItemId(motionPosition));
+                    performItemClick(view, motionPosition + mFirstPosition, adapter.getItemId(motionPosition + mFirstPosition));
                 }
             }
         }


### PR DESCRIPTION
I noticed that the row id being passed to `onItemClick()` was not being offset from the top visible item in the grid. I tracked the problem down to the `PerformClick` class where I saw that the offset being applied to the `position` was not being applied to the index that is used to retrieve the row id.
