### PR TITLE
Properly detech the orientation of the device.

### DIFF
--- a/library/src/main/java/com/etsy/android/grid/StaggeredGridView.java
+++ b/library/src/main/java/com/etsy/android/grid/StaggeredGridView.java
@@ -17,6 +17,7 @@
 package com.etsy.android.grid;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.content.res.TypedArray;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -241,13 +242,16 @@ public class StaggeredGridView extends ExtendableListView {
     // //////////////////////////////////////////////////////////////////////////////////////////
     // MEASUREMENT
     //
+    private boolean isLandscape() {
+        return getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE ? true : false;
+    }
 
     @Override
     protected void onMeasure(final int widthMeasureSpec, final int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 
         if (mColumnCount <= 0) {
-            boolean isLandscape = getMeasuredWidth() > getMeasuredHeight();
+            boolean isLandscape = isLandscape();
             mColumnCount = isLandscape ? mColumnCountLandscape : mColumnCountPortrait;
         }
 
@@ -860,7 +864,7 @@ public class StaggeredGridView extends ExtendableListView {
     @Override
     protected void onSizeChanged(int w, int h) {
     	super.onSizeChanged(w, h);
-    	boolean isLandscape = w > h;
+        boolean isLandscape = isLandscape();
         int newColumnCount = isLandscape ? mColumnCountLandscape : mColumnCountPortrait;
         if (mColumnCount != newColumnCount) {
             mColumnCount = newColumnCount;


### PR DESCRIPTION
When the keyboard is shown the gridview will improperly
think the device is in landscape.
