### PR TITLE
OnScrollListener issue after updating contents

### DIFF
--- a/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
+++ b/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
@@ -528,6 +528,7 @@ public abstract class ExtendableListView extends AbsListView {
 
             if (mAdapter == null) {
                 clearState();
+                invokeOnItemScrollListener();
                 return;
             }
 
@@ -551,6 +552,7 @@ public abstract class ExtendableListView extends AbsListView {
             // and calling it a day
             if (mItemCount == 0) {
                 clearState();
+                invokeOnItemScrollListener();
                 return;
             }
             else if (mItemCount != mAdapter.getCount()) {
@@ -613,6 +615,7 @@ public abstract class ExtendableListView extends AbsListView {
             mDataChanged = false;
             mNeedSync = false;
             mLayoutMode = LAYOUT_NORMAL;
+            invokeOnItemScrollListener();
         } finally {
             mBlockLayoutRequests = false;
         }


### PR DESCRIPTION
AbsListView.OnScrollListener.OnScroll(...) not called after using adapter.notifyDataSetChanged.

After a look at ListView.java from the framework, I found that there is invokeOnItemScrollListener calls in layoutChildren method that miss in your implementation.

This patch fix my issue, so I share it with everyone.
