### PR TITLE
LayoutParams casting issue when recycling state

### DIFF
--- a/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
+++ b/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
@@ -2593,9 +2593,10 @@ public abstract class ExtendableListView extends AbsListView {
         if (infos == null) return;
         for (FixedViewInfo info : infos) {
             final View child = info.view;
-            final LayoutParams p = (LayoutParams) child.getLayoutParams();
-            if (p != null) {
-                p.recycledHeaderFooter = false;
+            final ViewGroup.LayoutParams p = child.getLayoutParams();
+
+            if (p instanceof LayoutParams) {
+                ((LayoutParams) p).recycledHeaderFooter = false;
             }
         }
     }


### PR DESCRIPTION
If the StaggeredGridView has a headerview but no content there will a casting exception when casting
AbsListView.LayoutParams to StaggeredGridView.LayoutParams. This patch set confirms that the params
are an instance of StaggeredGridView.LayoutParams before proceeding.

Previously raised issue: https://github.com/etsy/AndroidStaggeredGrid/issues/94

```
java.lang.ClassCastException: android.widget.AbsListView$LayoutParams cannot be cast to com.etsy.android.grid.ExtendableListView$LayoutParams
            at com.etsy.android.grid.ExtendableListView.clearRecycledState(ExtendableListView.java:2596)
            at com.etsy.android.grid.ExtendableListView.clearState(ExtendableListView.java:2579)
            at com.etsy.android.grid.ExtendableListView.layoutChildren(ExtendableListView.java:553)
            at com.etsy.android.grid.StaggeredGridView.layoutChildren(StaggeredGridView.java:358)
            at com.etsy.android.grid.ExtendableListView.onLayout(ExtendableListView.java:513)
            at android.view.View.layout(View.java:14289)
            at android.view.ViewGroup.layout(ViewGroup.java:4559)
            at android.widget.RelativeLayout.onLayout(RelativeLayout.java:1076)
            at android.view.View.layout(View.java:14289)
            at android.view.ViewGroup.layout(ViewGroup.java:4559)
            at android.widget.FrameLayout.onLayout(FrameLayout.java:448)
            at android.view.View.layout(View.java:14289)
            at android.view.ViewGroup.layout(ViewGroup.java:4559)
            at android.widget.FrameLayout.onLayout(FrameLayout.java:448)
            at android.view.View.layout(View.java:14289)
            at android.view.ViewGroup.layout(ViewGroup.java:4559)
            at android.support.v4.widget.DrawerLayout.onLayout(DrawerLayout.java:743)
            at android.view.View.layout(View.java:14289)
            at android.view.ViewGroup.layout(ViewGroup.java:4559)
            at android.widget.FrameLayout.onLayout(FrameLayout.java:448)
            at android.view.View.layout(View.java:14289)
            at android.view.ViewGroup.layout(ViewGroup.java:4559)
            at com.android.internal.widget.ActionBarOverlayLayout.onLayout(ActionBarOverlayLayout.java:349)
            at android.view.View.layout(View.java:14289)
            at android.view.ViewGroup.layout(ViewGroup.java:4559)
            at android.widget.FrameLayout.onLayout(FrameLayout.java:448)
            at android.view.View.layout(View.java:14289)
            at android.view.ViewGroup.layout(ViewGroup.java:4559)
            at android.view.ViewRootImpl.performLayout(ViewRootImpl.java:1976)
            at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:1730)
            at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1004)
            at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:5481)
            at android.view.Choreographer$CallbackRecord.run(Choreographer.java:749)
            at android.view.Choreographer.doCallbacks(Choreographer.java:562)
            at android.view.Choreographer.doFrame(Choreographer.java:532)
            at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:735)
            at android.os.Handler.handleCallback(Handler.java:730)
            at android.os.Handler.dispatchMessage(Handler.java:92)
            at android.os.Looper.loop(Looper.java:137)
            at android.app.ActivityThread.main(ActivityThread.java:5103)
            at java.lang.reflect.Method.invokeNative(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:525)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:737)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:553)
            at dalvik.system.NativeStart.main(Native Method)
```
