### PR TITLE
Add updateEmptyStatus() in setAdapter() method

### DIFF
--- a/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
+++ b/library/src/main/java/com/etsy/android/grid/ExtendableListView.java
@@ -272,6 +272,7 @@ public abstract class ExtendableListView extends AbsListView {
             mRecycleBin.setViewTypeCount(mAdapter.getViewTypeCount());
         }
 
+        updateEmptyStatus();
         requestLayout();
     }
 


### PR DESCRIPTION
The `setAdapter(ListAdapter adapter)` method should also update empty status, otherwise if it is called later, the items won't be shown as the StaggeredGridView is in `Visibility.GONE`.
