### PR TITLE
Fix column positioning bug for Kindle devices

### DIFF
--- a/library/src/main/java/com/etsy/android/grid/StaggeredGridView.java
+++ b/library/src/main/java/com/etsy/android/grid/StaggeredGridView.java
@@ -259,6 +259,7 @@ public class StaggeredGridView extends ExtendableListView {
         // minus it's padding
         // minus the total items margin
         // divided by the number of columns
+        int previousColumnWidth = mColumnWidth;
         mColumnWidth = calculateColumnWidth(getMeasuredWidth());
 
         if (mColumnTops == null || mColumnTops.length != mColumnCount) {
@@ -269,7 +270,7 @@ public class StaggeredGridView extends ExtendableListView {
             mColumnBottoms = new int[mColumnCount];
             initColumnBottoms();
         }
-        if (mColumnLefts == null || mColumnLefts.length != mColumnCount) {
+        if (mColumnWidth != previousColumnWidth || mColumnLefts == null || mColumnLefts.length != mColumnCount) {
             mColumnLefts = new int[mColumnCount];
             initColumnLefts();
         }


### PR DESCRIPTION
...andscape, non-fullscreen Kindle devices where the width is first calculated without accounting for the options bar along the side, then recalculated with it)