### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ AndroidStaggeredGrid
 =====================
 
 
-##Notice - Deprecated - 09-2015
+## Notice - Deprecated - 09-2015
 
 This library has been deprecated. We will no longer be shipping any updates or approving community pull requests for this project.
 
@@ -11,7 +11,7 @@ While the code will remain for anyone who wishes to use it, we suggest you prefe
 
 Thanks to everyone who used the library and submitted code or issues to improve it.
 
-##About
+## About
 
 An Android staggered grid view which supports multiple columns with rows of varying sizes.
 
@@ -21,7 +21,7 @@ to sync grid position across orientation changes and support for headers & foote
 
 ![Staggered Grid Sample Image][1]
 
-##Features
+## Features
 
  * Configurable column count for portrait and landscape orientations.
  * Sync'd row position across orientation changes.
@@ -31,7 +31,7 @@ to sync grid position across orientation changes and support for headers & foote
  * Extends [`AbsListView`](http://developer.android.com/reference/android/widget/AbsListView.html) - "mostly"
  * Supports [`AbsListView.OnScrollListener`](http://developer.android.com/reference/android/widget/AbsListView.OnScrollListener.html)
 
-##Setup
+## Setup
 
 The library was built for and tested on Android version 2.3.3(SDK 10) and above. It could be modified to support older versions if required.
 
@@ -43,7 +43,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.etsy.android.grid:library:x.x.x' // see changelog
+    implementation 'com.etsy.android.grid:library:x.x.x' // see changelog
 }
 ```
 
@@ -56,7 +56,7 @@ The library is currently configured to be built via Gradle only. It has the foll
 
 Still use Eclipse/building with Ant? You can still use AndroidStaggeredGrid, it's just a few extra steps (left up to the reader).
 
-##Usage
+## Usage
 
 *Please see the `/sample` app for a more detailed code example of how to use the library.*
 
@@ -94,7 +94,7 @@ As column widths change on orientation change, the grid view expects that all ch
 maintain their own width to height ratio. To assist with this the project includes the
 `DynamicHeightImageView` as an example of a view that measures its height based on its width.
 
-##TODO
+## TODO
 
 The `StaggeredGridView` does not support the following:
 
@@ -106,7 +106,7 @@ The `StaggeredGridView` does not support the following:
  * Fading edge
  * Overscroll
 
-##License
+## License
 
     Copyright (c) 2013 Etsy
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.